### PR TITLE
Add release helpers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
-export default {
+module.exports = {
 	roots: ['<rootDir>/src'],
 	setupFilesAfterEnv: ['./jest.d.ts', './jest.extend.js'],
 	preset: 'ts-jest',

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "test": "npx jest",
     "release:validate": "yarn test && tsc && echo '✅ release ready to go' && echo git sha: `git rev-parse HEAD` && echo '> run release.sh to tag/publish'",
-    "release:tag": ""
+    "release": "node release.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,11 +40,13 @@
     "webpack-node-externals": "^3.0.0"
   },
   "scripts": {
-    "test": "npx jest"
+    "test": "npx jest",
+    "release:validate": "yarn test && tsc && echo '✅ release ready to go' && echo git sha: `git rev-parse HEAD` && echo '> run release.sh to tag/publish'",
+    "release:tag": ""
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/acmedinotech/txp.git"
+    "url": "https://github.com/acmedinotech/txp.git"
   },
   "keywords": [
     "text",

--- a/release.js
+++ b/release.js
@@ -1,0 +1,53 @@
+/**
+ * Semi-automated git tagging & publish to npm. Run this from *`main`* AFTER release
+ * PR is merged (i.e. version number changes)
+ */
+const readline = require('readline');
+const { exec } = require('child_process');
+
+const rl = readline.createInterface({
+	input: process.stdin,
+	output: process.stdout,
+});
+
+const prompt = async (prompt, defaultVal = '') => {
+	return new Promise((ok, err) => {
+		rl.question(`❓ ${prompt} `, (cmd) => {
+			ok(cmd == '' ? defaultVal : cmd);
+		});
+	});
+};
+
+const package = require('./package.json');
+
+(async () => {
+	console.log(`🔍 package version: ${package['version']})`);
+	const desc = await prompt(`release note (REQUIRED):`);
+	if (desc.trim() === '') {
+		console.error('❌ release note is required');
+		process.exit(1);
+	}
+
+	console.log(`⚠️  tag         : v${package['version']}`);
+	console.log(`⚠️  release note: ${desc}`);
+
+	const confirm = await prompt(`ready to tag and release? (y/N)`);
+	if (confirm.toLowerCase() != 'y') {
+		return;
+	}
+
+	exec(
+		`git tag -a v${package['version']} -m "${desc}" && git push --tags origin && npm publish --access public`,
+		(err, stdout, stderr) => {
+			console.log(`📺  ${stdout}`);
+			console.log(`🪵  ${stderr}`);
+			if (err) {
+				console.error(`❌`, err);
+				process.exit(1);
+			}
+
+			console.log(`✅  tagged and pushed!`);
+			process.exit(0);
+		}
+	);
+})();


### PR DESCRIPTION
created `yarn release` and `yarn release:validate` shortcuts to validate and publish releases. expected workflow:

- a release PR is created that increments the version and defines the release note as the commit message (1-line)
- `yarn release:validate` must succeed (requirement for any PR)
- release PR is merged
- `yarn release` is run from `main` that creates tag from current version and uses last commit message